### PR TITLE
fix grammar in project.clj :description

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject vlad "1.1.0"
   :description "Vlad is an attempt at providing convenient and simple
                validations. Vlad is purely functional and makes no assumptions
-               about your data. It can be used for validating html form data as
+               about your data. It can be used for validating html form data
                just as well as it can be used to validate your csv about cats."
   :url "https://github.com/logaan/vlad"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Hello.

This change removes one of the "as"s in the project.clj description. I think this fixes the grammar of the sentence. Also, I think this description is copied to the github description, so it would make sense to change that as well, if it is separate.
- Ryan
